### PR TITLE
Create protectiv routeing and redirections

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -13,9 +13,9 @@ import Places from "../Places/Places.js";
 import ForgotPassword from "../ForgotPassword/ForgotPassword.js";
 import Navigation from "../Navigation/Navigation.js";
 import { ProvideAuth } from "../Session/UserAuth.js";
-import { PrivateRoute } from "../PrivateRoute/PrivateRoute.js";
+import { PrivateRoute } from "../Route/PrivateRoute.js";
+import { AuthorizedRoute } from "../Route/AuthorizedRoute.js";
 
-import AddPlace from '../AddPlace/AddPlace.js';
 
 const App = () => {
   return (
@@ -24,16 +24,14 @@ const App = () => {
         <Navigation />
         <hr />
 
-        <Route exact path={ROUTES.LANDING} component={Landing} />
+        <AuthorizedRoute exact path={ROUTES.LANDING} component={Landing} />
         <Route exact path={ROUTES.ABOUT} component={About} />
-        <Route exact path={ROUTES.SIGN_UP} component={SignUp} />
-        <Route exact path={ROUTES.LOGIN} component={Login} />
-        <Route exact path={ROUTES.PROFILE} component={Profile} />
-        <Route exact path={ROUTES.PLACES} component={Places} />
-        <Route exact path={ROUTES.FORGOT_PASSWORD} component={ForgotPassword} />
+        <AuthorizedRoute exact path={ROUTES.SIGN_UP} component={SignUp} />
+        <AuthorizedRoute exact path={ROUTES.LOGIN} component={Login} />
+        <PrivateRoute exact path={ROUTES.PROFILE} component={Profile} />
+        <PrivateRoute exact path={ROUTES.PLACES} component={Places} />
+        <PrivateRoute exact path={ROUTES.FORGOT_PASSWORD} component={ForgotPassword} />
 
-        {/* Testing AddPlace component */}
-        <Route exact path = {ROUTES.ADD_PLACE} component={AddPlace} />
       </div>
     </ProvideAuth>
   );

--- a/src/components/Route/AuthorizedRoute.js
+++ b/src/components/Route/AuthorizedRoute.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { Route, Redirect } from "react-router-dom";
+import { useAuth } from "../Session/UserAuth";
+
+import * as ROUTES from "../../data/constants/routes.js";
+
+/**
+ * A wrapper for <Route> that redirects the user to places
+ * if the user is logged in.
+ */
+const AuthorizedRoute = ({ component: Component, ...rest }) => {
+  const auth = useAuth();
+
+  console.log("AuthorizedRoute auth: ", auth);
+
+  return auth.done ? (
+    // Show the component only when a user does not exist
+    // Otherwise, redirect the user to places
+    <Route
+      {...rest}
+      render={props =>
+        auth.user ? <Redirect to={ROUTES.PLACES} /> : <Component {...props} />
+      }
+    />
+  ) : null;
+};
+
+export { AuthorizedRoute };

--- a/src/components/Route/PrivateRoute.js
+++ b/src/components/Route/PrivateRoute.js
@@ -11,8 +11,7 @@ import * as ROUTES from "../../data/constants/routes.js";
 const PrivateRoute = ({ component: Component, ...rest }) => {
   const auth = useAuth();
 
-  console.log("private: ", auth);
-  return (
+  return auth.done ? (
     // Show the component only when the user is logged in
     // Otherwise, redirect the user to /signin page
     <Route
@@ -21,7 +20,7 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
         auth.user ? <Component {...props} /> : <Redirect to={ROUTES.LOGIN} />
       }
     />
-  );
+  ) : null;
 };
 
 export { PrivateRoute };

--- a/src/components/Session/UserAuth.js
+++ b/src/components/Session/UserAuth.js
@@ -30,7 +30,8 @@ export const useAuth = () => {
  * @return {Object} auth object
  */
 const useProvideAuth = () => {
-  const [user, setUser] = useState(JSON.parse(localStorage.getItem('authUser')));
+  const [user, setUser] = useState(null);   // Stores the authUser
+  const [done, setDone] = useState(false);  // True when we have user handler up
   const firebase = useFirebase();
 
   /**
@@ -43,9 +44,11 @@ const useProvideAuth = () => {
     const unsubscribe = firebase.auth.onAuthStateChanged(authUser => {
       if (authUser) {
         setUser(authUser);
+        setDone(true);
       }
       else {
         setUser(null);
+        setDone(true);
       }
     });
 
@@ -53,8 +56,18 @@ const useProvideAuth = () => {
     return () => unsubscribe();
   }, [firebase.auth]);
 
+
+  // If user was logged in from previouse session, set that as authUser
+  useEffect(() => {
+    const authUser = JSON.parse(localStorage.getItem('authUser'));
+    if (authUser) {
+      setUser(authUser);
+      setDone(true);
+    }
+  }, []);
+
   // Return the user object
   return (
-    {user: user}
+    {user, done}
   );
 }


### PR DESCRIPTION
This fixes #29 

This makes it so if we were logged in from before, we are immediately put on */places*. The implementation also protects pages. 

If not logged in the following pages will be unavailable.
- Places
- Forgot password 
- profile

if user is logged in the following pages will be unavailable
- Landing
- Signup
- Login