### PR TITLE
Image gallery only display when images are present

### DIFF
--- a/src/components/Place/Place.js
+++ b/src/components/Place/Place.js
@@ -31,9 +31,9 @@ const Place = ({ place }) => {
   return (
     <div className="Place">
       <h2 className="PlaceName">{place.name}</h2>
-      <div className="ImageGalleryContainer">
+      {images.length > 0 && <div className="ImageGalleryContainer">
         <ImageGallery items={images} showFullscreenButton={false}></ImageGallery>
-      </div>
+      </div>}
       <div className="PlaceTextContainer">
         <div className="PlaceInfo">
           <div className="PlaceLocation">


### PR DESCRIPTION
This fixes #88 

The image gallery was created in Place view even when we had no images. This pull request changes this and only creates the image gallery when we need it.