### PR TITLE
add placeholder for date input so it is shown on browsers that do not…

### DIFF
--- a/src/components/AddPlace/AddPlace.js
+++ b/src/components/AddPlace/AddPlace.js
@@ -132,6 +132,7 @@ const AddPlaceForm = ({ hide, preLocation }) => {
               type="date"
               onChange={evt => setDate(evt.target.value)}
               className="InputField1"
+              placeholder="dd/mm/yyyy"
             />
           </div>
           <div className="Row">


### PR DESCRIPTION
Add placeholder for date input so it is shown on browsers that do not support date picker such as Safari. Fixes #82 