### PR TITLE
Right click map now sets location data

### DIFF
--- a/src/components/AddPlace/AddPlace.js
+++ b/src/components/AddPlace/AddPlace.js
@@ -49,6 +49,7 @@ const AddPlaceForm = ({ hide, preLocation }) => {
         .then(data => {
           if (data.status.code == 200 && data.results.length > 0) {
             setLocation(data.results[0].formatted);
+            setLocationData(data.results[0]);
           }
         })
         .catch(error => {


### PR DESCRIPTION
This fixes #94 

Now sets location data when you right-click the map. This means that after right-clicking the map the user doesn't need to pick its location from a list.