### PR TITLE
Add benefits description and fix map background to center

### DIFF
--- a/src/components/Landing/Landing.css
+++ b/src/components/Landing/Landing.css
@@ -30,7 +30,20 @@
   min-height: 30px;
   width: 175px;
   padding: 10px 20px;
-  margin: 40px auto;
+  margin: 30px auto;
+}
+.LandingTextArea {
+  display: flex;
+}
+.TextBox {
+  width: 350px;
+  margin: 0 30px; 
+  /* background-color: rgba(228, 221, 211, 0.8); */
+  opacity: 0.8;
+}
+.TextBox p{
+  text-align: justify;
+  color: #111;
 }
 
 @media only screen and (max-width: 768px) {
@@ -39,6 +52,13 @@
     font-size: 20px;
   }
   .BtnSignUp {
-    margin-top: 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+  .LandingTextArea {
+    flex-direction: column;
+  }
+  .TextBox {
+    max-width: 320px;
   }
 }

--- a/src/components/Landing/Landing.css
+++ b/src/components/Landing/Landing.css
@@ -35,15 +35,6 @@
 
 @media only screen and (max-width: 768px) {
   /* For mobile phones: */
-  .LdBackgrImg {
-    height: 177.735px;
-    width: 431.42px;
-    position: absolute;
-    left: -35px;
-    right: 0;
-    margin-left: auto; 
-    margin-right: auto;
-  }
   .Tagline {
     font-size: 20px;
   }

--- a/src/components/Landing/Landing.js
+++ b/src/components/Landing/Landing.js
@@ -12,6 +12,16 @@ const Landing = () => {
         <div className="BtnSignUp LinkBtn1">
           <Link to={ROUTES.SIGN_UP}>Get Started Now</Link>
         </div>
+        <div className="LandingTextArea">
+          <div className="TextBox">
+            <h3>No more need for a paper wall map</h3>
+            <p>With WallMap you don't need any longer to buy an expensive paper map to hang on the wall and then buy pins to pin every place you have travelled to. You can do it all digitally in WallMap, and very easily. </p>
+          </div>
+          <div className="TextBox">
+            <h3>Save your memories on WallMap</h3>
+            <p>With WallMap we help you keep your memories of each place you have travelled to in the world. You can add photos and info to each place you visited. You simply add a pin to your WallMap and then add your images and info.</p>
+          </div>
+        </div>
       </div>
 
       <div className="Background"></div>
@@ -19,3 +29,5 @@ const Landing = () => {
   );
 };
 export default Landing;
+
+

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@ code {
   top: 0;
   background-color: rgba(228, 221, 211);
   background-image: url("./assets/images/world.svg");
-  background-size: cover;
+  background-size: contain;
   background-repeat: no-repeat;
   background-blend-mode: color-dodge;  
   min-width: 100%;


### PR DESCRIPTION
Added two benefits descriptions to the landing page (also responsive for mobile) and fix background map to be contained in the page and always be in the center. Fixes #102  